### PR TITLE
feat(ui): light theme, compact layout, and visual polish for readability

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,18 @@
+import { useState } from "react";
+
 import { NaturalEssenceCraftingApp } from "@/components/NaturalEssenceCraftingApp";
 
 export default function App() {
-  return <NaturalEssenceCraftingApp />;
+  const [compactMode, setCompactMode] = useState(true);
+
+  return (
+    <div data-compact={compactMode} className="min-h-screen bg-slate-50 text-slate-900">
+      <div className="max-w-6xl mx-auto p-6 compact-pad">
+        <NaturalEssenceCraftingApp
+          compactMode={compactMode}
+          onToggleCompactMode={(value) => setCompactMode(value)}
+        />
+      </div>
+    </div>
+  );
 }

--- a/src/components/DiceOverlay.tsx
+++ b/src/components/DiceOverlay.tsx
@@ -31,17 +31,19 @@ export function DiceOverlay({ rolls }: DiceOverlayProps) {
               initial={{ rotateX: -45, rotateY: 45 }}
               animate={{ rotateX: 0, rotateY: 0 }}
               transition={{ type: "spring", stiffness: 150, damping: 16 }}
-              className="relative flex min-w-[120px] flex-col gap-1 rounded-xl border border-white/20 bg-slate-900/90 px-4 py-3 text-white shadow-2xl backdrop-blur"
+              className="relative flex min-w-[140px] flex-col gap-1 rounded-xl border border-slate-200 bg-white px-4 py-3 text-slate-900 shadow-xl"
             >
-              <div className="text-xs uppercase tracking-wide text-white/70">{face.label}</div>
-              <div className="text-3xl font-bold leading-none">
-                {face.raw}
-                <span className="ml-1 text-base font-medium text-white/60">d20</span>
+              <div className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+                {face.label}
               </div>
-              <div className="text-sm text-white/70">
+              <div className="text-3xl font-bold leading-none text-slate-900">
+                {face.raw}
+                <span className="ml-1 text-base font-medium text-slate-500">d20</span>
+              </div>
+              <div className="text-sm text-slate-600">
                 Total {face.total} vs DC {face.dc}
               </div>
-              <div className={face.success ? "text-emerald-300" : "text-rose-300"}>
+              <div className={face.success ? "text-emerald-600" : "text-rose-600"}>
                 {face.success ? "Success" : "Fail"}
               </div>
             </motion.div>

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -3,9 +3,12 @@ import * as React from "react";
 import { cn } from "@/lib/util";
 
 const badgeVariants = {
-  default: "inline-flex items-center rounded-full bg-slate-900 px-2.5 py-0.5 text-xs font-medium text-white",
-  secondary: "inline-flex items-center rounded-full bg-slate-100 px-2.5 py-0.5 text-xs font-medium text-slate-700",
-  outline: "inline-flex items-center rounded-full border border-slate-200 px-2.5 py-0.5 text-xs font-medium",
+  default:
+    "inline-flex items-center rounded-full bg-indigo-600 px-2.5 py-0.5 text-xs font-semibold text-white",
+  secondary:
+    "inline-flex items-center rounded-full bg-slate-100 px-2.5 py-0.5 text-xs font-medium text-slate-700",
+  outline:
+    "inline-flex items-center rounded-full border border-slate-200 bg-white px-2.5 py-0.5 text-xs font-medium text-slate-700",
 };
 
 type Variant = keyof typeof badgeVariants;

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -8,18 +8,19 @@ export interface ButtonProps
   asChild?: boolean;
 }
 
-const buttonVariants = "inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50";
+const buttonVariants =
+  "inline-flex h-9 items-center justify-center whitespace-nowrap rounded-md px-3 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-50 disabled:cursor-not-allowed disabled:opacity-60";
 
 export const buttonStyles = {
-  default:
-    "bg-slate-900 text-white hover:bg-slate-900/90 focus-visible:ring-slate-500",
+  default: "bg-indigo-600 text-white hover:bg-indigo-700",
+  primary: "bg-indigo-600 text-white hover:bg-indigo-700",
   secondary:
-    "bg-white text-slate-900 hover:bg-slate-100 focus-visible:ring-slate-400 border border-slate-200",
+    "border border-slate-300 bg-white text-slate-700 hover:bg-slate-50",
   outline:
-    "border border-slate-200 bg-transparent hover:bg-slate-100 focus-visible:ring-slate-400",
-  ghost: "hover:bg-slate-100 hover:text-slate-900 focus-visible:ring-slate-300",
+    "border border-slate-300 bg-transparent text-slate-700 hover:bg-slate-50",
+  ghost: "text-slate-700 hover:bg-slate-100",
   destructive:
-    "bg-rose-500 text-white hover:bg-rose-500/90 focus-visible:ring-rose-400",
+    "bg-rose-600 text-white hover:bg-rose-700 focus-visible:ring-rose-500",
 };
 
 type VariantKey = keyof typeof buttonStyles;

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -7,7 +7,7 @@ export const Card = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDi
     <div
       ref={ref}
       className={cn(
-        "rounded-xl border border-slate-200/70 bg-white/70 p-6 shadow-sm backdrop-blur",
+        "rounded-2xl border border-slate-200 bg-white p-6 shadow-sm",
         className,
       )}
       {...props}
@@ -20,7 +20,7 @@ export const CardHeader = React.forwardRef<
   HTMLDivElement,
   React.HTMLAttributes<HTMLDivElement>
 >(({ className, ...props }, ref) => (
-  <div ref={ref} className={cn("mb-4 flex flex-col gap-1", className)} {...props} />
+  <div ref={ref} className={cn("mb-4 flex flex-col gap-1.5", className)} {...props} />
 ));
 CardHeader.displayName = "CardHeader";
 
@@ -28,7 +28,7 @@ export const CardTitle = React.forwardRef<HTMLParagraphElement, React.HTMLAttrib
   ({ className, ...props }, ref) => (
     <h3
       ref={ref}
-      className={cn("text-lg font-semibold leading-none tracking-tight", className)}
+      className={cn("text-lg font-semibold leading-tight", className)}
       {...props}
     />
   ),

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -9,7 +9,7 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(({ className
     <input
       type={type}
       className={cn(
-        "flex h-9 w-full rounded-md border border-slate-200 bg-white px-3 py-1 text-sm shadow-sm transition-colors placeholder:text-slate-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-500 disabled:cursor-not-allowed disabled:opacity-50",
+        "flex h-9 w-full rounded-md border border-slate-300 bg-white px-3 text-sm shadow-sm transition-colors placeholder:text-slate-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-1 disabled:cursor-not-allowed disabled:bg-slate-100 disabled:opacity-60",
         className,
       )}
       ref={ref}

--- a/src/components/ui/label.tsx
+++ b/src/components/ui/label.tsx
@@ -9,7 +9,7 @@ export const Label = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <LabelPrimitive.Root
     ref={ref}
-    className={cn("text-sm font-medium leading-none text-slate-700", className)}
+    className={cn("text-xs font-medium uppercase tracking-wide text-slate-700", className)}
     {...props}
   />
 ));

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -15,7 +15,7 @@ export const SelectTrigger = React.forwardRef<
   <SelectPrimitive.Trigger
     ref={ref}
     className={cn(
-      "flex h-9 w-full items-center justify-between rounded-md border border-slate-200 bg-white px-3 py-1 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-500 disabled:cursor-not-allowed disabled:opacity-50",
+      "flex h-9 w-full items-center justify-between rounded-md border border-slate-300 bg-white px-3 text-sm shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-1 disabled:cursor-not-allowed disabled:bg-slate-100 disabled:opacity-60",
       className,
     )}
     {...props}
@@ -36,7 +36,7 @@ export const SelectContent = React.forwardRef<
     <SelectPrimitive.Content
       ref={ref}
       className={cn(
-        "z-50 min-w-[8rem] overflow-hidden rounded-md border border-slate-200 bg-white text-slate-900 shadow-md",
+        "z-50 min-w-[8rem] overflow-hidden rounded-md border border-slate-200 bg-white text-slate-900 shadow-lg",
         className,
       )}
       position={position}
@@ -56,7 +56,7 @@ export const SelectLabel = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <SelectPrimitive.Label
     ref={ref}
-    className={cn("px-2 py-1.5 text-xs font-semibold text-slate-500", className)}
+    className={cn("px-2 py-1.5 text-xs font-semibold uppercase text-slate-500", className)}
     {...props}
   />
 ));
@@ -68,10 +68,10 @@ export const SelectItem = React.forwardRef<
 >(({ className, children, ...props }, ref) => (
   <SelectPrimitive.Item
     ref={ref}
-    className={cn(
-      "relative flex w-full cursor-pointer select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-slate-100 focus:text-slate-900",
-      className,
-    )}
+      className={cn(
+        "relative flex w-full cursor-pointer select-none items-center rounded-md px-2 py-1.5 text-sm outline-none focus:bg-slate-100 focus:text-slate-900",
+        className,
+      )}
     {...props}
   >
     <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">

--- a/src/components/ui/switch.tsx
+++ b/src/components/ui/switch.tsx
@@ -10,7 +10,7 @@ export const Switch = React.forwardRef<
   <SwitchPrimitives.Root
     ref={ref}
     className={cn(
-      "peer inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border border-transparent bg-slate-200 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-500 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-slate-900",
+      "peer inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border border-transparent bg-slate-300 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-50 disabled:cursor-not-allowed disabled:opacity-60 data-[state=checked]:bg-indigo-600",
       className,
     )}
     {...props}

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -12,7 +12,7 @@ export const TabsList = React.forwardRef<
   <TabsPrimitive.List
     ref={ref}
     className={cn(
-      "inline-flex h-10 items-center justify-center rounded-lg bg-slate-100 p-1 text-slate-600",
+      "inline-flex h-10 items-center justify-center rounded-full border border-slate-200 bg-white p-1 text-slate-600 shadow-sm",
       className,
     )}
     {...props}
@@ -27,7 +27,7 @@ export const TabsTrigger = React.forwardRef<
   <TabsPrimitive.Trigger
     ref={ref}
     className={cn(
-      "inline-flex min-w-[120px] items-center justify-center whitespace-nowrap rounded-md px-3 py-1.5 text-sm font-medium transition-all data-[state=active]:bg-white data-[state=active]:text-slate-900",
+      "inline-flex min-w-[110px] items-center justify-center whitespace-nowrap rounded-full px-4 py-1.5 text-sm font-medium transition-all data-[state=active]:bg-slate-100 data-[state=active]:text-slate-900 data-[state=active]:shadow-sm",
       className,
     )}
     {...props}

--- a/src/index.css
+++ b/src/index.css
@@ -3,16 +3,39 @@
 @tailwind utilities;
 
 :root {
-  color-scheme: light;
+  --background: 255 255 255;
+  --foreground: 15 23 42;
+  --muted: 248 250 252;
+  --muted-foreground: 100 116 139;
+  --card: 255 255 255;
+  --card-foreground: 15 23 42;
+  --border: 226 232 240;
+  --input: 203 213 225;
+  --ring: 99 102 241;
 }
 
-body {
-  margin: 0;
-  min-height: 100vh;
-  font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-  background-color: #0f172a;
-}
-
+html,
+body,
 #root {
-  min-height: 100vh;
+  height: 100%;
+}
+
+@layer base {
+  body {
+    margin: 0;
+    font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    background-color: #f8fafc;
+    color: #0f172a;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+  }
+}
+
+/* Compact mode utility */
+[data-compact="true"] .compact-gap {
+  gap: 0.75rem;
+}
+
+[data-compact="true"] .compact-pad {
+  padding: 0.5rem;
 }


### PR DESCRIPTION
## Summary
- enforce the new light theme tokens and compact mode wrapper state while exposing a toggle from the settings panel
- redesign the crafting dashboard with denser card layouts, requirement chips, and reorganized recent roll/history sections for readability
- refresh shared UI primitives and the dice overlay to match the high-contrast light styling

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dfb71b6c788333a2ea451835eaff59