### PR TITLE
Adjust CardContent layout defaults

### DIFF
--- a/src/components/NaturalEssenceCraftingApp.tsx
+++ b/src/components/NaturalEssenceCraftingApp.tsx
@@ -1142,7 +1142,7 @@ export function NaturalEssenceCraftingApp({
                   Latest main roll results with modifiers applied.
                 </CardDescription>
               </CardHeader>
-              <CardContent className="max-h-80 overflow-y-auto pr-1 gap-3">
+              <CardContent className="flex flex-col max-h-80 overflow-y-auto pr-1 gap-3">
                 {state.rolls.checks.length === 0 ? (
                   <p className="text-xs text-slate-500">No rolls yet.</p>
                 ) : (
@@ -1179,7 +1179,7 @@ export function NaturalEssenceCraftingApp({
                   Salvage checks from failed attempts.
                 </CardDescription>
               </CardHeader>
-              <CardContent className="max-h-80 overflow-y-auto pr-1 gap-3">
+              <CardContent className="flex flex-col max-h-80 overflow-y-auto pr-1 gap-3">
                 {state.rolls.salvages.length === 0 ? (
                   <p className="text-xs text-slate-500">No salvage rolls yet.</p>
                 ) : (
@@ -1217,7 +1217,7 @@ export function NaturalEssenceCraftingApp({
                 Latest attempts with resource deltas.
               </CardDescription>
             </CardHeader>
-            <CardContent className="max-h-80 overflow-y-auto pr-1 text-sm gap-3">
+            <CardContent className="flex flex-col max-h-80 overflow-y-auto pr-1 text-sm gap-3">
               {state.log.length === 0 ? (
                 <p className="text-xs text-slate-500">No crafting actions yet.</p>
               ) : (

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -47,7 +47,7 @@ export const CardContent = React.forwardRef<
   HTMLDivElement,
   React.HTMLAttributes<HTMLDivElement>
 >(({ className, ...props }, ref) => (
-  <div ref={ref} className={cn("flex flex-col gap-4", className)} {...props} />
+  <div ref={ref} className={cn("gap-4", className)} {...props} />
 ));
 CardContent.displayName = "CardContent";
 


### PR DESCRIPTION
## Summary
- allow `CardContent` to preserve shared gap spacing without forcing a flex layout
- add explicit flex column layout to recent roll and log sections that rely on column stacking

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dfd6a546448333b6dfdc49e032e9a8