### PR TITLE
Refactor crafting state into a persisted Zustand store

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,8 @@
         "lucide-react": "0.544.0",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
-        "tailwind-merge": "3.3.1"
+        "tailwind-merge": "3.3.1",
+        "zustand": "^5.0.8"
       },
       "devDependencies": {
         "@eslint/js": "^9.36.0",
@@ -6947,6 +6948,35 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.8.tgz",
+      "integrity": "sha512-gyPKpIaxY9XcO2vSMrLbiER7QMAMGOQZVRdJ6Zi782jkbzZygq5GI9nG8g+sMgitRtndwaBSl7uiqC49o1SSiw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "lucide-react": "0.544.0",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
-    "tailwind-merge": "3.3.1"
+    "tailwind-merge": "3.3.1",
+    "zustand": "^5.0.8"
   },
   "devDependencies": {
     "@eslint/js": "^9.36.0",

--- a/src/app/__tests__/store.test.ts
+++ b/src/app/__tests__/store.test.ts
@@ -1,0 +1,152 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import {
+  MAX_LOG_ENTRIES,
+  MAX_ROLL_HISTORY,
+  type ActionLogEntry,
+  type RollRecord,
+  useNaturalEssenceStore,
+} from "@/app/store";
+
+const timestamp = () => new Date().toISOString();
+
+const createRoll = (id: string, success = true): RollRecord => ({
+  id,
+  timestamp: timestamp(),
+  tier: "T2",
+  risk: "standard",
+  dc: 15,
+  raw: 12,
+  modifier: 3,
+  total: 15,
+  success,
+});
+
+const createEntry = (id: string): ActionLogEntry => ({
+  id,
+  timestamp: timestamp(),
+  tier: "T2",
+  risk: "standard",
+  text: `Entry ${id}`,
+});
+
+describe("natural essence store", () => {
+  beforeEach(() => {
+    useNaturalEssenceStore.persist.clearStorage?.();
+    useNaturalEssenceStore.getState().resetState();
+  });
+
+  it("clamps inventory changes to non-negative integers", () => {
+    const store = useNaturalEssenceStore.getState();
+
+    store.setInventoryValue("raw", 4.7);
+    expect(useNaturalEssenceStore.getState().inventory.raw).toBe(5);
+
+    store.setInventoryValue("raw", -12);
+    expect(useNaturalEssenceStore.getState().inventory.raw).toBe(0);
+  });
+
+  it("restores the most recent inventory snapshot", () => {
+    const store = useNaturalEssenceStore.getState();
+    store.setInventoryValue("raw", 8);
+    store.snapshotInventory();
+    store.setInventoryValue("raw", 2);
+
+    expect(useNaturalEssenceStore.getState().inventory.raw).toBe(2);
+
+    const restored = store.restoreInventory();
+    expect(restored).toBe(true);
+    expect(useNaturalEssenceStore.getState().inventory.raw).toBe(8);
+
+    const secondRestore = store.restoreInventory();
+    expect(secondRestore).toBe(false);
+  });
+
+  it("commits crafting results and trims history", () => {
+    const existingChecks = Array.from({ length: MAX_ROLL_HISTORY - 1 }, (_, index) =>
+      createRoll(`existing-check-${index}`),
+    );
+    const existingSalvages = Array.from({ length: MAX_ROLL_HISTORY - 1 }, (_, index) =>
+      createRoll(`existing-salvage-${index}`, false),
+    );
+    const existingEntries = Array.from({ length: MAX_LOG_ENTRIES - 1 }, (_, index) =>
+      createEntry(`existing-${index}`),
+    );
+
+    useNaturalEssenceStore.setState({
+      rolls: { checks: existingChecks, salvages: existingSalvages },
+      log: existingEntries,
+      sessionMinutes: 9,
+    });
+
+    const newChecks = [createRoll("new-check-1"), createRoll("new-check-0")];
+    const newSalvages = [createRoll("new-salvage-0", false)];
+    const newEntries = [createEntry("new-log-1"), createEntry("new-log-0")];
+    const manualChecks = [18, 4];
+    const manualSalvages = [7];
+
+    const nextInventory = {
+      ...useNaturalEssenceStore.getState().inventory,
+      raw: 3,
+    };
+
+    useNaturalEssenceStore
+      .getState()
+      .commitCraftingResult({
+        inventory: nextInventory,
+        checks: newChecks,
+        salvages: newSalvages,
+        logEntries: newEntries,
+        manualChecks,
+        manualSalvages,
+        minutes: 12,
+      });
+
+    const state = useNaturalEssenceStore.getState();
+
+    expect(state.inventory).not.toBe(nextInventory);
+    expect(state.inventory.raw).toBe(3);
+    expect(state.settings.manualCheckQueue).toEqual(manualChecks);
+    expect(state.settings.manualCheckQueue).not.toBe(manualChecks);
+    expect(state.settings.manualSalvageQueue).toEqual(manualSalvages);
+    expect(state.settings.manualSalvageQueue).not.toBe(manualSalvages);
+    expect(state.sessionMinutes).toBe(21);
+
+    expect(state.rolls.checks.length).toBe(MAX_ROLL_HISTORY);
+    expect(state.rolls.checks[0].id).toBe("new-check-1");
+    expect(state.rolls.checks[1].id).toBe("new-check-0");
+    expect(state.rolls.checks.slice(2).map((roll) => roll.id)).toEqual(
+      existingChecks.slice(0, MAX_ROLL_HISTORY - 2).map((roll) => roll.id),
+    );
+
+    expect(state.rolls.salvages.length).toBe(MAX_ROLL_HISTORY);
+    expect(state.rolls.salvages[0].id).toBe("new-salvage-0");
+    expect(state.rolls.salvages.slice(1).map((roll) => roll.id)).toEqual(
+      existingSalvages.slice(0, MAX_ROLL_HISTORY - 1).map((roll) => roll.id),
+    );
+
+    expect(state.log.length).toBe(MAX_LOG_ENTRIES);
+    expect(state.log[0].id).toBe("new-log-1");
+    expect(state.log[1].id).toBe("new-log-0");
+    expect(state.log[2].id).toBe("existing-0");
+  });
+
+  it("prepends log entries while enforcing the cap", () => {
+    const existingEntries = Array.from({ length: MAX_LOG_ENTRIES - 2 }, (_, index) =>
+      createEntry(`existing-${index}`),
+    );
+
+    useNaturalEssenceStore.setState({ log: existingEntries });
+
+    useNaturalEssenceStore.getState().appendLogEntries([
+      createEntry("new-a"),
+      createEntry("new-b"),
+      createEntry("new-c"),
+    ]);
+
+    const { log } = useNaturalEssenceStore.getState();
+    expect(log.length).toBe(MAX_LOG_ENTRIES);
+    expect(log.slice(0, 3).map((entry) => entry.id)).toEqual(["new-a", "new-b", "new-c"]);
+    expect(log[3].id).toBe("existing-0");
+  });
+});

--- a/src/app/store.ts
+++ b/src/app/store.ts
@@ -1,0 +1,220 @@
+import { create } from "zustand";
+import { createJSONStorage, persist } from "zustand/middleware";
+import type { StateStorage } from "zustand/middleware";
+
+import type { AdvantageMode } from "@/lib/math";
+import {
+  EMPTY_INVENTORY,
+  type Inventory,
+  type RiskLevel,
+  type TierKey,
+} from "@/lib/rules";
+import { STORAGE_KEY } from "@/lib/storage";
+
+export const MAX_ROLL_HISTORY = 12;
+export const MAX_LOG_ENTRIES = 120;
+
+export type RollMode = "auto" | "manual";
+
+export interface Settings {
+  rollMode: RollMode;
+  advantage: AdvantageMode;
+  modifier: number;
+  manualCheckQueue: number[];
+  manualSalvageQueue: number[];
+}
+
+export interface RollRecord {
+  id: string;
+  timestamp: string;
+  tier: TierKey;
+  risk: RiskLevel;
+  dc: number;
+  raw: number;
+  modifier: number;
+  total: number;
+  success: boolean;
+}
+
+export interface RollsState {
+  checks: RollRecord[];
+  salvages: RollRecord[];
+}
+
+export interface ActionLogEntry {
+  id: string;
+  timestamp: string;
+  tier: TierKey | "system";
+  risk?: RiskLevel;
+  text: string;
+}
+
+export interface NaturalEssenceCraftingState {
+  inventory: Inventory;
+  settings: Settings;
+  log: ActionLogEntry[];
+  rolls: RollsState;
+  sessionMinutes: number;
+  prevInventory: Inventory | null;
+  statusMessage: string | null;
+}
+
+export interface NaturalEssenceCraftingActions {
+  setStatusMessage: (message: string | null) => void;
+  clearStatusMessage: () => void;
+  setInventoryValue: (key: keyof Inventory, value: number) => void;
+  setInventory: (inventory: Inventory) => void;
+  snapshotInventory: (inventory?: Inventory) => void;
+  restoreInventory: () => boolean;
+  clearInventory: () => void;
+  updateSettings: (patch: Partial<Settings>) => void;
+  updateManualQueue: (type: "check" | "salvage", queue: number[]) => void;
+  appendLogEntries: (entries: ActionLogEntry[]) => void;
+  commitCraftingResult: (payload: {
+    inventory: Inventory;
+    checks: RollRecord[];
+    salvages: RollRecord[];
+    logEntries: ActionLogEntry[];
+    manualChecks: number[];
+    manualSalvages: number[];
+    minutes: number;
+  }) => void;
+  resetState: () => void;
+}
+
+export type NaturalEssenceCraftingStore = NaturalEssenceCraftingState &
+  NaturalEssenceCraftingActions;
+
+const createDefaultState = (): NaturalEssenceCraftingState => ({
+  inventory: { ...EMPTY_INVENTORY },
+  settings: {
+    rollMode: "auto",
+    advantage: "normal",
+    modifier: 0,
+    manualCheckQueue: [],
+    manualSalvageQueue: [],
+  },
+  log: [],
+  rolls: { checks: [], salvages: [] },
+  sessionMinutes: 0,
+  prevInventory: null,
+  statusMessage: null,
+});
+
+const memoryStorage = (() => {
+  const storage = new Map<string, string>();
+  const api: StateStorage = {
+    getItem: (name) => storage.get(name) ?? null,
+    setItem: (name, value) => {
+      storage.set(name, value);
+    },
+    removeItem: (name) => {
+      storage.delete(name);
+    },
+  };
+  return api;
+})();
+
+const storageCreator = () =>
+  typeof window !== "undefined" ? window.localStorage : memoryStorage;
+
+export const useNaturalEssenceStore = create<NaturalEssenceCraftingStore>()(
+  persist(
+    (set, get) => ({
+      ...createDefaultState(),
+      setStatusMessage: (message) => set({ statusMessage: message }),
+      clearStatusMessage: () => set({ statusMessage: null }),
+      setInventoryValue: (key, value) =>
+        set((state) => ({
+          inventory: {
+            ...state.inventory,
+            [key]: Math.max(0, Math.round(value)),
+          },
+        })),
+      setInventory: (inventory) =>
+        set({
+          inventory: { ...EMPTY_INVENTORY, ...inventory },
+        }),
+      snapshotInventory: (inventory) =>
+        set((state) => ({
+          prevInventory: { ...(inventory ?? state.inventory) },
+        })),
+      restoreInventory: () => {
+        const { prevInventory } = get();
+        if (!prevInventory) {
+          return false;
+        }
+        set({ inventory: { ...prevInventory }, prevInventory: null });
+        return true;
+      },
+      clearInventory: () =>
+        set((state) => ({
+          prevInventory: { ...state.inventory },
+          inventory: { ...EMPTY_INVENTORY },
+        })),
+      updateSettings: (patch) =>
+        set((state) => ({
+          settings: { ...state.settings, ...patch },
+        })),
+      updateManualQueue: (type, queue) =>
+        set((state) => ({
+          settings: {
+            ...state.settings,
+            manualCheckQueue:
+              type === "check" ? [...queue] : state.settings.manualCheckQueue,
+            manualSalvageQueue:
+              type === "salvage" ? [...queue] : state.settings.manualSalvageQueue,
+          },
+        })),
+      appendLogEntries: (entries) =>
+        set((state) => ({
+          log: [...entries, ...state.log].slice(0, MAX_LOG_ENTRIES),
+        })),
+      commitCraftingResult: ({
+        inventory,
+        checks,
+        salvages,
+        logEntries,
+        manualChecks,
+        manualSalvages,
+        minutes,
+      }) =>
+        set((state) => ({
+          inventory: { ...inventory },
+          settings: {
+            ...state.settings,
+            manualCheckQueue: [...manualChecks],
+            manualSalvageQueue: [...manualSalvages],
+          },
+          rolls: {
+            checks: [...checks, ...state.rolls.checks].slice(0, MAX_ROLL_HISTORY),
+            salvages: [...salvages, ...state.rolls.salvages].slice(
+              0,
+              MAX_ROLL_HISTORY,
+            ),
+          },
+          log: [...logEntries, ...state.log].slice(0, MAX_LOG_ENTRIES),
+          sessionMinutes: state.sessionMinutes + minutes,
+        })),
+      resetState: () =>
+        set({
+          ...createDefaultState(),
+        }),
+    }),
+    {
+      name: STORAGE_KEY,
+      storage: createJSONStorage(storageCreator),
+      partialize: (state) => ({
+        inventory: state.inventory,
+        settings: state.settings,
+        log: state.log,
+        rolls: state.rolls,
+        sessionMinutes: state.sessionMinutes,
+        prevInventory: state.prevInventory,
+        statusMessage: state.statusMessage,
+      }),
+    },
+  ),
+);
+
+export const getDefaultState = createDefaultState;


### PR DESCRIPTION
## Summary
- add a typed Zustand store with undo snapshots, status messaging, and localStorage persistence for crafting state
- refactor NaturalEssenceCraftingApp to consume store selectors/actions instead of component-level state helpers
- add unit tests for store reducers and register the zustand dependency

## Testing
- npx vitest run

------
https://chatgpt.com/codex/tasks/task_e_68e10f119564833395f4504ed3e73f7a