### PR TITLE
Refactor rules engine for configurable families

### DIFF
--- a/src/lib/__tests__/rules.test.ts
+++ b/src/lib/__tests__/rules.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it } from "vitest";
 
 import {
-  MIN_DC,
   computeDc,
   computeMaxAttempts,
   computeSuccessProfile,
+  getMinimumDc,
 } from "@/lib/rules";
 import type { Inventory } from "@/lib/rules";
 
@@ -27,10 +27,11 @@ describe("rules helpers", () => {
     expect(disadvantaged.salvageChance).toBe(normal.salvageChance);
   });
 
-  it("clamps T4 DC using MIN_DC", () => {
+  it("clamps T4 DC using the minimum DC", () => {
     const { dc } = computeDc("T4", "high", 10);
-    expect(dc).toBeGreaterThanOrEqual(MIN_DC);
-    expect(dc).toBe(MIN_DC);
+    const minDc = getMinimumDc();
+    expect(dc).toBeGreaterThanOrEqual(minDc);
+    expect(dc).toBe(minDc);
   });
 
   it("computes feasible attempts for several tiers", () => {

--- a/src/rules/natural.ts
+++ b/src/rules/natural.ts
@@ -1,0 +1,126 @@
+import type { EssenceFamily } from "@/rules/types";
+
+export const naturalEssenceFamily: EssenceFamily = {
+  key: "natural",
+  label: "Natural essence crafting",
+  description: "Track inventory, roll checks, and keep your refinement pipeline humming.",
+  minDc: 5,
+  resources: [
+    { key: "raw", label: "T1 Raw" },
+    { key: "fine", label: "T2 Fine" },
+    { key: "fused", label: "T3 Fused" },
+    { key: "superior", label: "T4 Superior" },
+    { key: "supreme", label: "T5 Supreme" },
+    { key: "rawAE", label: "Raw Arcane Essence" },
+  ],
+  riskProfiles: [
+    { key: "low", label: "Low" },
+    { key: "standard", label: "Standard" },
+    { key: "high", label: "High" },
+  ],
+  tiers: [
+    {
+      key: "T2",
+      label: "Tier 2 · Fine Essence",
+      subtitle: "Refine Raw → Fine",
+      gradient: "from-emerald-400 to-emerald-600",
+      success: { fine: 1 },
+      risks: [
+        {
+          risk: "low",
+          dc: 5,
+          costs: { raw: 3 },
+          timeMinutes: 30,
+          salvage: { dc: 8, returns: { raw: 2 } },
+        },
+        {
+          risk: "standard",
+          dc: 12,
+          costs: { raw: 2 },
+          timeMinutes: 60,
+          salvage: { dc: 12, returns: { raw: 1 } },
+        },
+        {
+          risk: "high",
+          dc: 20,
+          costs: { raw: 1 },
+          timeMinutes: 120,
+        },
+      ],
+    },
+    {
+      key: "T3",
+      label: "Tier 3 · Fused Essence",
+      subtitle: "Infuse Fine + RawAE → Fused",
+      gradient: "from-sky-400 to-sky-600",
+      success: { fused: 1 },
+      risks: [
+        {
+          risk: "standard",
+          dc: 12,
+          costs: { fine: 2, rawAE: 2 },
+          timeMinutes: 30,
+          salvage: { dc: 10, returns: { fine: 2 } },
+        },
+      ],
+    },
+    {
+      key: "T4",
+      label: "Tier 4 · Superior Essence",
+      subtitle: "Refine Fused (+RawAE) → Superior",
+      gradient: "from-violet-400 to-violet-600",
+      success: { superior: 1 },
+      dcReduction: {
+        resource: "rawAE",
+        perUnit: 4,
+        minDc: 5,
+      },
+      risks: [
+        {
+          risk: "low",
+          dc: 12,
+          costs: { fused: 3 },
+          timeMinutes: 60,
+          salvage: { dc: 10, returns: { fine: 5 } },
+        },
+        {
+          risk: "standard",
+          dc: 18,
+          costs: { fused: 2 },
+          timeMinutes: 120,
+          salvage: { dc: 14, returns: { fine: 3 } },
+        },
+        {
+          risk: "high",
+          dc: 34,
+          costs: { fused: 1 },
+          timeMinutes: 480,
+          salvage: { dc: 18, returns: { fine: 1 } },
+        },
+      ],
+    },
+    {
+      key: "T5",
+      label: "Tier 5 · Supreme Essence",
+      subtitle: "Refine Superior → Supreme",
+      gradient: "from-amber-400 to-amber-600",
+      success: { supreme: 1 },
+      risks: [
+        {
+          risk: "standard",
+          dc: 12,
+          costs: { superior: 3 },
+          timeMinutes: 60,
+          salvage: { dc: 10, returns: { superior: 2 } },
+        },
+        {
+          risk: "high",
+          dc: 18,
+          costs: { superior: 2 },
+          timeMinutes: 120,
+          salvage: { dc: 15, returns: { superior: 1 } },
+        },
+      ],
+    },
+  ],
+};

--- a/src/rules/types.ts
+++ b/src/rules/types.ts
@@ -1,0 +1,55 @@
+export type ResourceKey = string;
+export type TierKey = string;
+export type RiskKey = string;
+
+export type Inventory = Record<ResourceKey, number>;
+
+export interface ResourceDefinition {
+  key: ResourceKey;
+  label: string;
+}
+
+export interface RiskProfile {
+  key: RiskKey;
+  label: string;
+  description?: string;
+}
+
+export interface SalvageRule {
+  dc: number;
+  returns: Partial<Inventory>;
+}
+
+export interface TierRisk {
+  risk: RiskKey;
+  dc: number;
+  costs: Partial<Inventory>;
+  timeMinutes: number;
+  salvage?: SalvageRule;
+}
+
+export interface DcReductionRule {
+  resource: ResourceKey;
+  perUnit: number;
+  minDc: number;
+}
+
+export interface TierAction {
+  key: TierKey;
+  label: string;
+  subtitle: string;
+  gradient: string;
+  success: Partial<Inventory>;
+  risks: TierRisk[];
+  dcReduction?: DcReductionRule;
+}
+
+export interface EssenceFamily {
+  key: string;
+  label: string;
+  description?: string;
+  minDc: number;
+  resources: ResourceDefinition[];
+  riskProfiles: RiskProfile[];
+  tiers: TierAction[];
+}


### PR DESCRIPTION
## Summary
- define reusable essence family, tier, risk, and inventory types plus the Natural Essence configuration
- refactor the rules engine to consume the active family for DC math, attempt costs, metadata access, and smoke tests
- update the crafting UI to derive resources, risks, and tier tabs from the family config while handling dynamic extra-resource inputs

## Testing
- npm run test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68e10f2b2ba483338fea889de7f5e035