### PR TITLE
Capture final crafting rolls in overlay and add tests

### DIFF
--- a/src/components/NaturalEssenceCraftingApp.tsx
+++ b/src/components/NaturalEssenceCraftingApp.tsx
@@ -352,7 +352,6 @@ export function NaturalEssenceCraftingApp({
 
     if (feasible <= 0) {
       setStatusMessage("Insufficient resources for that action.");
-      setDiceOverlay(null);
       return;
     }
 
@@ -365,7 +364,8 @@ export function NaturalEssenceCraftingApp({
     const newChecks: RollRecord[] = [];
     const newSalvages: RollRecord[] = [];
     const newLog: ActionLogEntry[] = [];
-    const overlayFaces: DiceFace[] = [];
+    let lastCheckFace: DiceFace | null = null;
+    let lastSalvageFace: DiceFace | null = null;
     const now = new Date();
     let attemptsCompleted = 0;
     let totalMinutes = 0;
@@ -374,6 +374,9 @@ export function NaturalEssenceCraftingApp({
       if (!hasResources(workingInventory, attemptCosts)) {
         break;
       }
+
+      lastCheckFace = null;
+      lastSalvageFace = null;
 
       const before = cloneInventory(workingInventory);
       workingInventory = applyInventoryDelta(workingInventory, scaleDelta(attemptCosts, -1));
@@ -410,6 +413,15 @@ export function NaturalEssenceCraftingApp({
       };
       newChecks.unshift(checkRecord);
 
+      lastCheckFace = {
+        id: checkRecord.id,
+        label: `${tier} ${risk} check`,
+        raw: rawRoll,
+        total,
+        dc,
+        success,
+      };
+
       let salvageInfo = "";
       if (!success && riskRule.salvage) {
         const salvageRoll = state.settings.rollMode === "manual"
@@ -434,16 +446,14 @@ export function NaturalEssenceCraftingApp({
         };
         newSalvages.unshift(salvageRecord);
 
-        if (attemptsRequested === 1) {
-          overlayFaces.push({
-            id: salvageRecord.id,
-            label: "Salvage",
-            raw: salvageRoll,
-            total: salvageTotal,
-            dc: riskRule.salvage.dc,
-            success: salvageSuccess,
-          });
-        }
+        lastSalvageFace = {
+          id: salvageRecord.id,
+          label: `${tier} ${risk} salvage`,
+          raw: salvageRoll,
+          total: salvageTotal,
+          dc: riskRule.salvage.dc,
+          success: salvageSuccess,
+        };
       }
 
       const after = cloneInventory(workingInventory);
@@ -457,24 +467,12 @@ export function NaturalEssenceCraftingApp({
       };
       newLog.unshift(entry);
 
-      if (attemptsRequested === 1) {
-        overlayFaces.unshift({
-          id: checkRecord.id,
-          label: "Main Check",
-          raw: rawRoll,
-          total,
-          dc,
-          success,
-        });
-      }
-
       attemptsCompleted += 1;
       totalMinutes += riskRule.timeMinutes;
     }
 
     if (attemptsCompleted === 0) {
       setStatusMessage("Ran out of resources before any attempts could begin.");
-      setDiceOverlay(null);
       return;
     }
 
@@ -501,7 +499,10 @@ export function NaturalEssenceCraftingApp({
       };
     });
 
-    if (attemptsRequested === 1) {
+    if (lastCheckFace) {
+      const overlayFaces = [lastCheckFace, lastSalvageFace].filter(
+        (face): face is DiceFace => Boolean(face),
+      );
       setDiceOverlay(overlayFaces);
     } else {
       setDiceOverlay(null);

--- a/src/components/__tests__/NaturalEssenceCraftingApp.test.tsx
+++ b/src/components/__tests__/NaturalEssenceCraftingApp.test.tsx
@@ -1,0 +1,90 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { cleanup, fireEvent, render, screen, within } from "@testing-library/react";
+
+import { NaturalEssenceCraftingApp } from "../NaturalEssenceCraftingApp";
+
+function renderApp() {
+  return render(
+    <NaturalEssenceCraftingApp compactMode={false} onToggleCompactMode={() => {}} />,
+  );
+}
+
+function enableManualMode() {
+  const [toggle] = screen.getAllByRole("switch", { name: "Toggle auto rolling" });
+  fireEvent.click(toggle);
+}
+
+function commitManualInput(label: string, value: string) {
+  const input = screen.getByLabelText(label);
+  fireEvent.change(input, { target: { value } });
+  fireEvent.blur(input);
+  return input;
+}
+
+describe("NaturalEssenceCraftingApp dice overlay", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("records the final attempt when running batch actions", async () => {
+    renderApp();
+
+    commitManualInput("T1 Raw", "10");
+    enableManualMode();
+
+    commitManualInput("Manual check rolls (comma separated)", "1,20");
+    commitManualInput("Manual salvage rolls (comma separated)", "5");
+
+    const batchInput = screen.getByLabelText("Batch size", { selector: "input" });
+    fireEvent.change(batchInput, { target: { value: "2" } });
+
+    const runButtonText = await screen.findByText("Run batch (2)");
+    const runButton = runButtonText.closest("button");
+    expect(runButton).toBeTruthy();
+    fireEvent.click(runButton!);
+
+    const checkLabel = await screen.findByText("T2 standard check");
+    const checkCard = checkLabel.parentElement;
+
+    expect(checkCard).toBeTruthy();
+    expect(within(checkCard as HTMLElement).getByText("20")).toBeDefined();
+    expect(screen.queryByText("T2 standard salvage")).toBeNull();
+  });
+
+  it("shows check and salvage rolls for salvage-only runs and keeps the overlay visible", async () => {
+    renderApp();
+
+    commitManualInput("T1 Raw", "10");
+    enableManualMode();
+
+    const manualChecks = commitManualInput("Manual check rolls (comma separated)", "1");
+    commitManualInput("Manual salvage rolls (comma separated)", "15");
+
+    const batchInput = screen.getByLabelText("Batch size", { selector: "input" });
+    fireEvent.change(batchInput, { target: { value: "1" } });
+
+    const runButton = screen
+      .getAllByRole("button")
+      .find((btn) => btn.textContent?.includes("Run batch"));
+    expect(runButton).toBeDefined();
+    fireEvent.click(runButton!);
+
+    const checkLabel = await screen.findByText("T2 standard check");
+    const salvageLabel = await screen.findByText("T2 standard salvage");
+
+    const checkCard = checkLabel.parentElement as HTMLElement;
+    const salvageCard = salvageLabel.parentElement as HTMLElement;
+
+    expect(within(checkCard).getByText(/Fail/i)).toBeDefined();
+    expect(within(salvageCard).getByText(/Success/i)).toBeDefined();
+
+    fireEvent.change(manualChecks, { target: { value: "2" } });
+    fireEvent.blur(manualChecks);
+
+    expect(screen.getByText("T2 standard salvage")).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary
- update crafting runs to capture the last attempt's check and salvage rolls for the dice overlay and keep previous results when no roll occurs
- label overlay faces with tier and risk information so batched runs surface their final results
- add UI tests that cover batched overlays and salvage-only scenarios to guard the behaviour

## Testing
- npm test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68e10f30ca088333a1b40080cbe4b83d