### PR TITLE
Capture inventory undo snapshot before manual edits

### DIFF
--- a/src/components/NaturalEssenceCraftingApp.tsx
+++ b/src/components/NaturalEssenceCraftingApp.tsx
@@ -281,6 +281,7 @@ export function NaturalEssenceCraftingApp({
     state.settings.rollMode === "auto" ? state.settings.advantage : "normal";
 
   const handleInventoryChange = (key: keyof Inventory, value: number) => {
+    setPrevInventory((snapshot) => snapshot ?? cloneInventory(state.inventory));
     setState((prev) => ({
       ...prev,
       inventory: {

--- a/src/components/__tests__/inventory-undo.test.tsx
+++ b/src/components/__tests__/inventory-undo.test.tsx
@@ -1,0 +1,36 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { NaturalEssenceCraftingApp } from "../NaturalEssenceCraftingApp";
+
+describe("inventory manual edits", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it("can be undone immediately without losing the original snapshot", () => {
+    render(
+      <NaturalEssenceCraftingApp compactMode={false} onToggleCompactMode={() => {}} />,
+    );
+
+    const rawInput = screen.getByLabelText("T1 Raw") as HTMLInputElement;
+    const undoButton = screen.getByRole("button", { name: /undo/i });
+
+    expect(rawInput.value).toBe("0");
+
+    fireEvent.change(rawInput, { target: { value: "10" } });
+    expect(rawInput.value).toBe("10");
+
+    fireEvent.change(rawInput, { target: { value: "5" } });
+    expect(rawInput.value).toBe("5");
+
+    fireEvent.click(undoButton);
+    expect(rawInput.value).toBe("0");
+
+    fireEvent.change(rawInput, { target: { value: "3" } });
+    expect(rawInput.value).toBe("3");
+
+    fireEvent.click(undoButton);
+    expect(rawInput.value).toBe("0");
+  });
+});


### PR DESCRIPTION
## Summary
- capture the current inventory in the undo buffer before applying manual input updates
- avoid overwriting the stored snapshot during consecutive edits and cover the flow with a regression test

## Testing
- npx vitest run

------
https://chatgpt.com/codex/tasks/task_e_68e10f3397308333940ff69afae25623