### PR TITLE
Add dark mode theme support and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,9 @@ The development server runs on [http://localhost:5173](http://localhost:5173). T
 - Animated dice overlay for the latest single attempt plus dual-column recent roll history.
 - Detailed action log, smoke test diagnostics, and session timers for flavour time tracking.
 - Game rules, feasibility checks, and probability helpers covered by Vitest unit tests.
+
+## Theming & accessibility
+
+- Light and dark palettes are driven by CSS variables that respect the system `prefers-color-scheme` setting.
+- A dark-mode toggle is available in the Settings panel to override the system preference at any time.
+- Semantic Tailwind tokens (e.g. `bg-background`, `text-foreground`, `border-border`) replace fixed hex values to guarantee consistent contrast in both themes.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,7 +6,7 @@ export default function App() {
   const [compactMode, setCompactMode] = useState(true);
 
   return (
-    <div data-compact={compactMode} className="min-h-screen bg-slate-50 text-slate-900">
+    <div data-compact={compactMode} className="min-h-screen bg-background text-foreground transition-colors">
       <div className="max-w-6xl mx-auto p-6 compact-pad">
         <NaturalEssenceCraftingApp
           compactMode={compactMode}

--- a/src/components/DiceOverlay.tsx
+++ b/src/components/DiceOverlay.tsx
@@ -42,19 +42,19 @@ export function DiceOverlay({ rolls }: DiceOverlayProps) {
               initial={prefersReducedMotion ? { opacity: 0 } : { rotateX: -45, rotateY: 45 }}
               animate={prefersReducedMotion ? { opacity: 1 } : { rotateX: 0, rotateY: 0 }}
               transition={faceTransition}
-              className="relative flex min-w-[140px] flex-col gap-1 rounded-xl border border-slate-200/80 bg-white px-4 py-3 text-slate-900 shadow-xl"
+              className="relative flex min-w-[140px] flex-col gap-1 rounded-xl border border-border/80 bg-card px-4 py-3 text-card-foreground shadow-xl"
             >
-              <div className="text-xs font-semibold text-slate-500">
+              <div className="text-xs font-semibold text-muted-foreground">
                 {face.label}
               </div>
-              <div className="text-3xl font-bold leading-none text-slate-900">
+              <div className="text-3xl font-bold leading-none text-card-foreground">
                 {face.raw}
-                <span className="ml-1 text-base font-medium text-slate-500">d20</span>
+                <span className="ml-1 text-base font-medium text-muted-foreground">d20</span>
               </div>
-              <div className="text-sm text-slate-600">
+              <div className="text-sm text-muted-foreground">
                 Total {face.total} vs DC {face.dc}
               </div>
-              <div className={face.success ? "text-emerald-600" : "text-rose-600"}>
+              <div className={face.success ? "text-success-foreground" : "text-destructive-foreground"}>
                 {face.success ? "Success" : "Fail"}
               </div>
             </motion.div>

--- a/src/components/NaturalEssenceCraftingApp.tsx
+++ b/src/components/NaturalEssenceCraftingApp.tsx
@@ -16,6 +16,7 @@ import {
 
 import { DiceOverlay } from "@/components/DiceOverlay";
 import type { DiceFace } from "@/components/DiceOverlay";
+import { useTheme } from "@/components/theme/ThemeProvider";
 import { Button } from "@/components/ui/button";
 import {
   Card,
@@ -129,14 +130,14 @@ const createDefaultState = (): AppState => ({
 const TIER_ORDER: TierKey[] = ["T2", "T3", "T4", "T5"];
 
 const TIER_GRADIENTS: Record<TierKey, string> = {
-  T2: "from-emerald-400 to-emerald-600",
-  T3: "from-sky-400 to-sky-600",
-  T4: "from-violet-400 to-violet-600",
-  T5: "from-amber-400 to-amber-600",
+  T2: "from-tier-2-start to-tier-2-end",
+  T3: "from-tier-3-start to-tier-3-end",
+  T4: "from-tier-4-start to-tier-4-end",
+  T5: "from-tier-5-start to-tier-5-end",
 };
 
 const focusRing =
-  "focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2";
+  "focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background";
 
 const Chip = ({
   ok = true,
@@ -154,8 +155,8 @@ const Chip = ({
     className={cn(
       "inline-flex items-center gap-1 rounded-full border px-2.5 py-1 text-xs font-medium shadow-sm",
       ok
-        ? "border-emerald-200 bg-emerald-50 text-emerald-700"
-        : "border-rose-200 bg-rose-50 text-rose-700",
+        ? "border-success-border bg-success text-success-foreground"
+        : "border-destructive-border bg-destructive text-destructive-foreground",
       className,
     )}
   >
@@ -263,6 +264,7 @@ export function NaturalEssenceCraftingApp({
   const [statusMessage, setStatusMessage] = useState<string | null>(null);
   const [manualCheckText, setManualCheckText] = useState<string>("");
   const [manualSalvageText, setManualSalvageText] = useState<string>("");
+  const { theme, setTheme } = useTheme();
 
   useEffect(() => {
     saveState(state);
@@ -550,7 +552,7 @@ export function NaturalEssenceCraftingApp({
       );
     });
 
-    return chips.length > 0 ? chips : <span className="text-xs text-slate-500">No net change</span>;
+    return chips.length > 0 ? chips : <span className="text-xs text-muted-foreground">No net change</span>;
   };
 
   const renderTierPanel = (tier: TierKey) => {
@@ -652,19 +654,19 @@ export function NaturalEssenceCraftingApp({
     const runButtonLabel = disabledReason ? "Unavailable" : `Run batch (${attempts})`;
 
     return (
-      <Card className="rounded-2xl border border-slate-200 bg-white shadow-sm">
+      <Card className="rounded-2xl border border-border bg-card shadow-sm">
         <CardHeader className="space-y-1">
-          <CardTitle className="text-lg font-semibold text-slate-900">
+          <CardTitle className="text-lg font-semibold text-card-foreground">
             <span
               className={`bg-gradient-to-r ${TIER_GRADIENTS[tier]} bg-clip-text text-transparent`}
             >
               {rule.subtitle}
             </span>
           </CardTitle>
-          <CardDescription className="text-[11px] text-slate-500">
+          <CardDescription className="text-[11px] text-muted-foreground">
             {riskRule.timeMinutes} minutes per attempt · DC {dc}
             {tier === "T4" && wastedExtra > 0 ? (
-              <span className="ml-1 text-amber-600">
+              <span className="ml-1 text-destructive-foreground">
                 {wastedExtra} RawAE wasted beyond DC {MIN_DC}
               </span>
             ) : null}
@@ -722,7 +724,7 @@ export function NaturalEssenceCraftingApp({
                         [tier]: clampInt(Number(event.target.value), 1, 999),
                       }))
                     }
-                    className="h-9 w-24 text-center focus-visible:ring-2 focus-visible:ring-indigo-500"
+                    className="h-9 w-24 text-center focus-visible:ring-2 focus-visible:ring-ring"
                   />
                   <Button
                     type="button"
@@ -743,7 +745,7 @@ export function NaturalEssenceCraftingApp({
                     variant="outline"
                     className={cn(
                       focusRing,
-                      "h-9 px-3 text-xs text-indigo-600 hover:text-indigo-700",
+                      "h-9 px-3 text-xs text-primary hover:text-primary/80",
                     )}
                     onClick={() =>
                       setAttemptCounts((prev) => ({
@@ -778,7 +780,7 @@ export function NaturalEssenceCraftingApp({
                       onChange={(event) =>
                         setT4ExtraRawAE(Math.max(0, Math.round(Number(event.target.value))))
                       }
-                      className="h-9 w-24 text-center focus-visible:ring-2 focus-visible:ring-indigo-500"
+                      className="h-9 w-24 text-center focus-visible:ring-2 focus-visible:ring-ring"
                     />
                     <Button
                       type="button"
@@ -789,7 +791,7 @@ export function NaturalEssenceCraftingApp({
                     >
                       <Plus className="h-4 w-4" aria-hidden="true" />
                     </Button>
-                    <p className="text-[11px] text-slate-500">
+                    <p className="text-[11px] text-muted-foreground">
                       Lowers DC by 4 each (minimum {MIN_DC}).
                     </p>
                   </div>
@@ -797,14 +799,14 @@ export function NaturalEssenceCraftingApp({
               ) : null}
 
               <div className="space-y-1">
-                <p className="text-[11px] font-medium text-slate-500">
+                <p className="text-[11px] font-medium text-muted-foreground">
                   Requirements for {attempts} attempt{attempts === 1 ? "" : "s"}
                 </p>
                 <div className="flex flex-wrap gap-2">
                   {requirementChips.length > 0 ? (
                     requirementChips
                   ) : (
-                    <span className="text-xs text-slate-500">No resources required.</span>
+                    <span className="text-xs text-muted-foreground">No resources required.</span>
                   )}
                 </div>
               </div>
@@ -819,7 +821,7 @@ export function NaturalEssenceCraftingApp({
                       title={disabledReason ?? undefined}
                       className={cn(
                         focusRing,
-                        "w-full justify-center bg-indigo-600 text-white hover:bg-indigo-700",
+                        "w-full justify-center bg-primary text-primary-foreground hover:bg-primary/90",
                         disabledReason ? "cursor-not-allowed opacity-60" : "",
                       )}
                     >
@@ -833,26 +835,26 @@ export function NaturalEssenceCraftingApp({
 
             <div className="space-y-3">
               <div className="space-y-2">
-                <p className="text-sm font-semibold text-slate-700">Snapshot</p>
+                <p className="text-sm font-semibold text-foreground">Snapshot</p>
                 <div className="flex flex-wrap gap-2">
                   <Chip title="Chance main check succeeds">Success {successPct}%</Chip>
                   {salvagePct !== undefined ? (
                     <Chip title="Chance salvage succeeds">Salvage {salvagePct}%</Chip>
                   ) : null}
-                  <Chip className="border-indigo-200 bg-indigo-50 text-indigo-700" title="Difficulty class">
+                  <Chip className="border-accent-border bg-accent text-accent-foreground" title="Difficulty class">
                     DC {dc}
                   </Chip>
                   <Chip ok={feasibilityOk} title="Attempts you can afford right now">
                     Feasible {feasibleLabel}
                   </Chip>
                   <Chip
-                    className="border-slate-200 bg-white text-slate-700"
+                    className="border-border bg-card text-foreground"
                     title="Time required for this batch"
                   >
                     Time {formatMinutes(totalTime)}
                   </Chip>
                   <Chip
-                    className="border-slate-200 bg-white text-slate-700"
+                    className="border-border bg-card text-foreground"
                     title="Resources consumed each attempt"
                   >
                     Consumes {consumptionSummary || "nothing"}
@@ -861,34 +863,34 @@ export function NaturalEssenceCraftingApp({
               </div>
 
               <div className="space-y-1">
-                <p className="text-sm font-semibold text-slate-700">Consumes per attempt</p>
+                <p className="text-sm font-semibold text-foreground">Consumes per attempt</p>
                 <div className="flex flex-wrap gap-2">
                   {consumesPerAttempt.length > 0 ? (
                     consumesPerAttempt
                   ) : (
-                    <span className="text-xs text-slate-500">No costs.</span>
+                    <span className="text-xs text-muted-foreground">No costs.</span>
                   )}
                 </div>
               </div>
 
               <div className="space-y-1">
-                <p className="text-sm font-semibold text-slate-700">On success</p>
+                <p className="text-sm font-semibold text-foreground">On success</p>
                 <div className="flex flex-wrap gap-2">
                   {producesOnSuccess.length > 0 ? (
                     producesOnSuccess
                   ) : (
-                    <span className="text-xs text-slate-500">No resource change.</span>
+                    <span className="text-xs text-muted-foreground">No resource change.</span>
                   )}
                 </div>
               </div>
 
               <div className="space-y-2">
-                <div className="flex items-center gap-2 text-sm font-semibold text-slate-700">
-                  <Calculator className="h-4 w-4 text-indigo-600" aria-hidden="true" />
+                <div className="flex items-center gap-2 text-sm font-semibold text-foreground">
+                  <Calculator className="h-4 w-4 text-primary" aria-hidden="true" />
                   Expected value per attempt
                   <Tooltip>
                     <TooltipTrigger aria-label="Expected value explanation">
-                      <Info className="h-4 w-4 text-slate-400" aria-hidden="true" />
+                      <Info className="h-4 w-4 text-muted-foreground" aria-hidden="true" />
                     </TooltipTrigger>
                     <TooltipContent>
                       Success, failure, and salvage chances combined into an average resource change per attempt.
@@ -913,31 +915,31 @@ export function NaturalEssenceCraftingApp({
         <header className="space-y-3">
           <div className="flex flex-wrap items-center justify-between gap-3">
             <div className="flex items-center gap-2">
-              <FlaskConical className="h-7 w-7 text-indigo-600" aria-hidden="true" />
-              <h1 className="text-2xl font-semibold text-slate-900">Natural essence crafting</h1>
+              <FlaskConical className="h-7 w-7 text-primary" aria-hidden="true" />
+              <h1 className="text-2xl font-semibold text-card-foreground">Natural essence crafting</h1>
             </div>
             <div className="flex flex-wrap gap-2">
-              <Chip className="border-slate-200 bg-white text-slate-700" title="Session duration">
+              <Chip className="border-border bg-card text-foreground" title="Session duration">
                 Session {formatMinutes(state.sessionMinutes)}
               </Chip>
-              <Chip className="border-slate-200 bg-white text-slate-700" title="Log entries recorded">
+              <Chip className="border-border bg-card text-foreground" title="Log entries recorded">
                 Log {state.log.length}
               </Chip>
-              <Chip className="border-slate-200 bg-white text-slate-700" title="Total recent rolls tracked">
+              <Chip className="border-border bg-card text-foreground" title="Total recent rolls tracked">
                 Rolls {state.rolls.checks.length + state.rolls.salvages.length}
               </Chip>
             </div>
           </div>
-          <p className="text-sm text-slate-600">
+          <p className="text-sm text-muted-foreground">
             Track inventory, roll checks, and keep your refinement pipeline humming.
           </p>
         </header>
 
         <div className="grid gap-4 md:grid-cols-3">
-          <Card className="md:col-span-2 rounded-2xl border border-slate-200 bg-white shadow-sm">
+          <Card className="md:col-span-2 rounded-2xl border border-border bg-card shadow-sm">
             <CardHeader className="space-y-1">
-              <CardTitle className="text-lg font-semibold text-slate-900">Inventory</CardTitle>
-              <CardDescription className="text-[11px] text-slate-500">
+              <CardTitle className="text-lg font-semibold text-card-foreground">Inventory</CardTitle>
+              <CardDescription className="text-[11px] text-muted-foreground">
                 Update your current stock. Crafting actions adjust automatically.
               </CardDescription>
             </CardHeader>
@@ -945,7 +947,7 @@ export function NaturalEssenceCraftingApp({
               <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
                 {RESOURCES.map((resource) => (
                   <div key={resource} className="flex items-center justify-between gap-3">
-                    <Label htmlFor={`inv-${resource}`} className="text-sm font-medium text-slate-600">
+                    <Label htmlFor={`inv-${resource}`} className="text-sm font-medium text-muted-foreground">
                       {RESOURCE_LABELS[resource]}
                     </Label>
                     <Input
@@ -956,7 +958,7 @@ export function NaturalEssenceCraftingApp({
                       onChange={(event) =>
                         handleInventoryChange(resource, Math.max(0, Number(event.target.value)))
                       }
-                      className="h-9 w-24 text-right focus-visible:ring-2 focus-visible:ring-indigo-500"
+                      className="h-9 w-24 text-right focus-visible:ring-2 focus-visible:ring-ring"
                     />
                   </div>
                 ))}
@@ -982,10 +984,10 @@ export function NaturalEssenceCraftingApp({
             </CardContent>
           </Card>
 
-          <Card className="rounded-2xl border border-slate-200 bg-white shadow-sm">
+          <Card className="rounded-2xl border border-border bg-card shadow-sm">
             <CardHeader className="space-y-1">
-              <CardTitle className="text-lg font-semibold text-slate-900">Settings & rolls</CardTitle>
-              <CardDescription className="text-[11px] text-slate-500">
+              <CardTitle className="text-lg font-semibold text-card-foreground">Settings & rolls</CardTitle>
+              <CardDescription className="text-[11px] text-muted-foreground">
                 Configure modifiers, rolling behaviour, and queue manual results.
               </CardDescription>
             </CardHeader>
@@ -1006,7 +1008,7 @@ export function NaturalEssenceCraftingApp({
                         },
                       }))
                     }
-                    className="h-9 w-24 focus-visible:ring-2 focus-visible:ring-indigo-500"
+                    className="h-9 w-24 focus-visible:ring-2 focus-visible:ring-ring"
                   />
                 </div>
                 <div className="flex flex-col gap-1.5">
@@ -1034,19 +1036,19 @@ export function NaturalEssenceCraftingApp({
                     </SelectContent>
                   </Select>
                   {state.settings.rollMode === "manual" ? (
-                    <p className="text-[11px] text-slate-500">Manual mode always rolls a single d20.</p>
+                    <p className="text-[11px] text-muted-foreground">Manual mode always rolls a single d20.</p>
                   ) : null}
                 </div>
               </div>
 
               <div className="grid gap-3">
-                <div className="rounded-2xl border border-slate-200 bg-slate-50/70 px-4 py-3">
+                <div className="rounded-2xl border border-border bg-muted/70 px-4 py-3">
                   <div className="flex items-center justify-between gap-4">
                     <div>
-                      <p className="text-sm font-semibold text-slate-700">Auto rolling</p>
-                      <p className="text-[11px] text-slate-500">Toggle manual queues for precise control.</p>
+                      <p className="text-sm font-semibold text-foreground">Auto rolling</p>
+                      <p className="text-[11px] text-muted-foreground">Toggle manual queues for precise control.</p>
                     </div>
-                    <div className="flex items-center gap-2 text-xs font-medium text-slate-600">
+                    <div className="flex items-center gap-2 text-xs font-medium text-muted-foreground">
                       <span>Manual</span>
                       <Switch
                         aria-label="Toggle auto rolling"
@@ -1066,16 +1068,30 @@ export function NaturalEssenceCraftingApp({
                   </div>
                 </div>
 
-                <div className="rounded-2xl border border-slate-200 bg-slate-50/70 px-4 py-3">
+                <div className="rounded-2xl border border-border bg-muted/70 px-4 py-3">
                   <div className="flex items-center justify-between gap-4">
                     <div>
-                      <p className="text-sm font-semibold text-slate-700">Compact mode</p>
-                      <p className="text-[11px] text-slate-500">Reduce padding and gaps across the interface.</p>
+                      <p className="text-sm font-semibold text-foreground">Compact mode</p>
+                      <p className="text-[11px] text-muted-foreground">Reduce padding and gaps across the interface.</p>
                     </div>
                     <Switch
                       aria-label="Toggle compact layout"
                       checked={compactMode}
                       onCheckedChange={(checked) => onToggleCompactMode(checked)}
+                    />
+                  </div>
+                </div>
+
+                <div className="rounded-2xl border border-border bg-muted/70 px-4 py-3">
+                  <div className="flex items-center justify-between gap-4">
+                    <div>
+                      <p className="text-sm font-semibold text-foreground">Dark mode</p>
+                      <p className="text-[11px] text-muted-foreground">Switch between light and dark palettes.</p>
+                    </div>
+                    <Switch
+                      aria-label="Toggle dark mode"
+                      checked={theme === "dark"}
+                      onCheckedChange={(checked) => setTheme(checked ? "dark" : "light")}
                     />
                   </div>
                 </div>
@@ -1096,7 +1112,7 @@ export function NaturalEssenceCraftingApp({
                       }
                     }}
                     placeholder="e.g. 12,5,18"
-                    className="h-9 focus-visible:ring-2 focus-visible:ring-indigo-500"
+                    className="h-9 focus-visible:ring-2 focus-visible:ring-ring"
                   />
                 </div>
                 <div className="flex flex-col gap-1.5">
@@ -1113,7 +1129,7 @@ export function NaturalEssenceCraftingApp({
                       }
                     }}
                     placeholder="e.g. 7,16"
-                    className="h-9 focus-visible:ring-2 focus-visible:ring-indigo-500"
+                    className="h-9 focus-visible:ring-2 focus-visible:ring-ring"
                   />
                 </div>
               </div>
@@ -1129,7 +1145,7 @@ export function NaturalEssenceCraftingApp({
                 </Button>
               </div>
 
-              <div className="rounded-2xl border border-slate-200 bg-slate-50/70 px-4 py-3 text-xs text-slate-600">
+              <div className="rounded-2xl border border-border bg-muted/70 px-4 py-3 text-xs text-muted-foreground">
                 <p>
                   Recent rolls: {state.rolls.checks.length} main · {state.rolls.salvages.length} salvage.
                 </p>
@@ -1140,8 +1156,8 @@ export function NaturalEssenceCraftingApp({
         </div>
 
         {statusMessage ? (
-          <div className="flex items-center gap-2 rounded-2xl border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-700 shadow-sm">
-            <BadgeCheck className="h-4 w-4" aria-hidden="true" />
+          <div className="flex items-center gap-2 rounded-2xl border border-success-border bg-success px-4 py-3 text-sm text-success-foreground shadow-sm">
+            <BadgeCheck className="h-4 w-4 text-success-foreground" aria-hidden="true" />
             {statusMessage}
           </div>
         ) : null}
@@ -1151,12 +1167,12 @@ export function NaturalEssenceCraftingApp({
           onValueChange={(value) => setActiveTier(value as TierKey)}
           className="flex flex-col gap-4"
         >
-          <TabsList className="grid grid-cols-4 sticky top-0 z-10 border-b border-slate-200 bg-slate-50/90 backdrop-blur">
+          <TabsList className="grid grid-cols-4 sticky top-0 z-10 border-b border-border bg-muted/90 backdrop-blur">
             {TIER_ORDER.map((tier) => (
               <TabsTrigger
                 key={tier}
                 value={tier}
-                className="rounded-none px-3 py-2 text-sm font-medium text-slate-600 data-[state=active]:border-b-2 data-[state=active]:border-indigo-500 data-[state=active]:text-indigo-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500"
+                className="rounded-none px-3 py-2 text-sm font-medium text-muted-foreground data-[state=active]:border-b-2 data-[state=active]:border-primary data-[state=active]:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
               >
                 {tier}
               </TabsTrigger>
@@ -1171,74 +1187,74 @@ export function NaturalEssenceCraftingApp({
 
         <div className="grid gap-6 lg:grid-cols-[2fr_1fr]">
           <div className="grid gap-6 md:grid-cols-2">
-            <Card className="rounded-2xl border border-slate-200 bg-white shadow-sm">
+            <Card className="rounded-2xl border border-border bg-card shadow-sm">
               <CardHeader className="space-y-1">
-                <CardTitle className="text-lg font-semibold text-slate-900">Recent checks</CardTitle>
-                <CardDescription className="text-[11px] text-slate-500">
+                <CardTitle className="text-lg font-semibold text-card-foreground">Recent checks</CardTitle>
+                <CardDescription className="text-[11px] text-muted-foreground">
                   Latest main roll results with modifiers applied.
                 </CardDescription>
               </CardHeader>
               <CardContent className="flex max-h-80 flex-col gap-3 overflow-y-auto pr-1">
                 {state.rolls.checks.length === 0 ? (
-                  <p className="text-xs text-slate-500">No rolls yet.</p>
+                  <p className="text-xs text-muted-foreground">No rolls yet.</p>
                 ) : (
                   state.rolls.checks.map((roll) => (
                     <div
                       key={roll.id}
-                      className="flex flex-col gap-1 rounded-xl border border-slate-200 bg-white px-3 py-2 shadow-sm"
+                      className="flex flex-col gap-1 rounded-xl border border-border bg-card px-3 py-2 shadow-sm"
                     >
-                      <div className="flex items-center justify-between text-[11px] text-slate-500">
+                      <div className="flex items-center justify-between text-[11px] text-muted-foreground">
                         <span>{new Date(roll.timestamp).toLocaleTimeString()}</span>
                         <span>
                           {roll.tier} · {roll.risk}
                         </span>
                       </div>
-                      <div className="flex items-center justify-between font-mono text-xs text-slate-900">
+                      <div className="flex items-center justify-between font-mono text-xs text-card-foreground">
                         <span>
                           d20 {roll.raw} + {roll.modifier} = {roll.total}
                         </span>
-                        <span className={roll.success ? "text-emerald-600" : "text-rose-600"}>
+                        <span className={roll.success ? "text-success-foreground" : "text-destructive-foreground"}>
                           {roll.success ? "✓" : "✗"}
                         </span>
                       </div>
-                      <p className="font-mono text-[11px] text-slate-500">DC {roll.dc}</p>
+                      <p className="font-mono text-[11px] text-muted-foreground">DC {roll.dc}</p>
                     </div>
                   ))
                 )}
               </CardContent>
             </Card>
 
-            <Card className="rounded-2xl border border-slate-200 bg-white shadow-sm">
+            <Card className="rounded-2xl border border-border bg-card shadow-sm">
               <CardHeader className="space-y-1">
-                <CardTitle className="text-lg font-semibold text-slate-900">Recent salvage</CardTitle>
-                <CardDescription className="text-[11px] text-slate-500">
+                <CardTitle className="text-lg font-semibold text-card-foreground">Recent salvage</CardTitle>
+                <CardDescription className="text-[11px] text-muted-foreground">
                   Salvage checks from failed attempts.
                 </CardDescription>
               </CardHeader>
               <CardContent className="flex max-h-80 flex-col gap-3 overflow-y-auto pr-1">
                 {state.rolls.salvages.length === 0 ? (
-                  <p className="text-xs text-slate-500">No salvage rolls yet.</p>
+                  <p className="text-xs text-muted-foreground">No salvage rolls yet.</p>
                 ) : (
                   state.rolls.salvages.map((roll) => (
                     <div
                       key={roll.id}
-                      className="flex flex-col gap-1 rounded-xl border border-slate-200 bg-white px-3 py-2 shadow-sm"
+                      className="flex flex-col gap-1 rounded-xl border border-border bg-card px-3 py-2 shadow-sm"
                     >
-                      <div className="flex items-center justify-between text-[11px] text-slate-500">
+                      <div className="flex items-center justify-between text-[11px] text-muted-foreground">
                         <span>{new Date(roll.timestamp).toLocaleTimeString()}</span>
                         <span>
                           {roll.tier} · {roll.risk}
                         </span>
                       </div>
-                      <div className="flex items-center justify-between font-mono text-xs text-slate-900">
+                      <div className="flex items-center justify-between font-mono text-xs text-card-foreground">
                         <span>
                           d20 {roll.raw} + {roll.modifier} = {roll.total}
                         </span>
-                        <span className={roll.success ? "text-emerald-600" : "text-rose-600"}>
+                        <span className={roll.success ? "text-success-foreground" : "text-destructive-foreground"}>
                           {roll.success ? "✓" : "✗"}
                         </span>
                       </div>
-                      <p className="font-mono text-[11px] text-slate-500">DC {roll.dc}</p>
+                      <p className="font-mono text-[11px] text-muted-foreground">DC {roll.dc}</p>
                     </div>
                   ))
                 )}
@@ -1246,29 +1262,29 @@ export function NaturalEssenceCraftingApp({
             </Card>
           </div>
 
-          <Card className="rounded-2xl border border-slate-200 bg-white shadow-sm">
+          <Card className="rounded-2xl border border-border bg-card shadow-sm">
             <CardHeader className="space-y-1">
-              <CardTitle className="text-lg font-semibold text-slate-900">Action log</CardTitle>
-              <CardDescription className="text-[11px] text-slate-500">
+              <CardTitle className="text-lg font-semibold text-card-foreground">Action log</CardTitle>
+              <CardDescription className="text-[11px] text-muted-foreground">
                 Latest attempts with resource deltas.
               </CardDescription>
             </CardHeader>
             <CardContent className="flex max-h-80 flex-col gap-3 overflow-y-auto pr-1 text-sm">
               {state.log.length === 0 ? (
-                <p className="text-xs text-slate-500">No crafting actions yet.</p>
+                <p className="text-xs text-muted-foreground">No crafting actions yet.</p>
               ) : (
                 state.log.map((entry) => (
                   <div
                     key={entry.id}
-                    className="flex flex-col gap-1 rounded-xl border border-slate-200 bg-white px-3 py-2 shadow-sm"
+                    className="flex flex-col gap-1 rounded-xl border border-border bg-card px-3 py-2 shadow-sm"
                   >
-                    <div className="flex items-center justify-between text-[11px] text-slate-500">
+                    <div className="flex items-center justify-between text-[11px] text-muted-foreground">
                       <span>{new Date(entry.timestamp).toLocaleTimeString()}</span>
                       <span>
                         {entry.tier === "system" ? "System" : `${entry.tier} · ${entry.risk}`}
                       </span>
                     </div>
-                    <p className="text-sm text-slate-700">{entry.text}</p>
+                    <p className="text-sm text-foreground">{entry.text}</p>
                   </div>
                 ))
               )}

--- a/src/components/theme/ThemeProvider.test.tsx
+++ b/src/components/theme/ThemeProvider.test.tsx
@@ -1,0 +1,88 @@
+import { cleanup, fireEvent, render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ThemeProvider, THEME_STORAGE_KEY, useTheme } from "@/components/theme/ThemeProvider";
+
+function createMatchMedia(matches: boolean) {
+  return vi.fn().mockImplementation((query: string) => ({
+    matches,
+    media: query,
+    onchange: null,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  } as MediaQueryList));
+}
+
+function ThemeReporter() {
+  const { theme } = useTheme();
+  return <span data-testid="theme-value">{theme}</span>;
+}
+
+function ThemeToggleButton() {
+  const { theme, toggleTheme } = useTheme();
+  return (
+    <button type="button" onClick={() => toggleTheme()}>
+      toggle-{theme}
+    </button>
+  );
+}
+
+describe("ThemeProvider", () => {
+  beforeEach(() => {
+    cleanup();
+    window.localStorage.clear();
+    document.documentElement.className = "";
+    document.documentElement.removeAttribute("data-theme");
+    document.body.innerHTML = "";
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("defaults to the system dark preference and toggles themes", () => {
+    Object.defineProperty(window, "matchMedia", {
+      writable: true,
+      value: createMatchMedia(true),
+    });
+
+    const { getByTestId, getByRole } = render(
+      <ThemeProvider>
+        <ThemeReporter />
+        <ThemeToggleButton />
+      </ThemeProvider>,
+    );
+
+    expect(getByTestId("theme-value").textContent).toBe("dark");
+    expect(document.documentElement.classList.contains("dark")).toBe(true);
+    expect(document.documentElement.dataset.theme).toBe("dark");
+
+    fireEvent.click(getByRole("button", { name: /toggle/i }));
+
+    expect(getByTestId("theme-value").textContent).toBe("light");
+    expect(document.documentElement.classList.contains("dark")).toBe(false);
+    expect(document.documentElement.dataset.theme).toBe("light");
+    expect(window.localStorage.getItem(THEME_STORAGE_KEY)).toBe("light");
+  });
+
+  it("prefers stored overrides instead of the system preference", () => {
+    window.localStorage.setItem(THEME_STORAGE_KEY, "light");
+    Object.defineProperty(window, "matchMedia", {
+      writable: true,
+      value: createMatchMedia(true),
+    });
+
+    const { getByTestId } = render(
+      <ThemeProvider>
+        <ThemeReporter />
+      </ThemeProvider>,
+    );
+
+    expect(getByTestId("theme-value").textContent).toBe("light");
+    expect(document.documentElement.classList.contains("dark")).toBe(false);
+    expect(document.documentElement.dataset.theme).toBe("light");
+  });
+});

--- a/src/components/theme/ThemeProvider.tsx
+++ b/src/components/theme/ThemeProvider.tsx
@@ -1,0 +1,91 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import type { ReactNode } from "react";
+
+type Theme = "light" | "dark";
+
+interface ThemeContextValue {
+  theme: Theme;
+  setTheme: (theme: Theme) => void;
+  toggleTheme: () => void;
+}
+
+export const THEME_STORAGE_KEY = "essencecraft-theme";
+
+const ThemeContext = createContext<ThemeContextValue | null>(null);
+
+const getPreferredTheme = (): Theme => {
+  if (typeof window === "undefined") {
+    return "light";
+  }
+
+  const stored = window.localStorage.getItem(THEME_STORAGE_KEY) as Theme | null;
+  if (stored === "light" || stored === "dark") {
+    return stored;
+  }
+
+  const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
+  return mediaQuery.matches ? "dark" : "light";
+};
+
+const applyTheme = (theme: Theme) => {
+  if (typeof document === "undefined") return;
+
+  const root = document.documentElement;
+  root.classList.toggle("dark", theme === "dark");
+  root.dataset.theme = theme;
+};
+
+export function ThemeProvider({ children }: { children: ReactNode }) {
+  const [theme, setThemeState] = useState<Theme>(() => getPreferredTheme());
+  const hasExplicitPreference = useRef<boolean>(false);
+
+  useEffect(() => {
+    applyTheme(theme);
+    if (typeof window !== "undefined") {
+      window.localStorage.setItem(THEME_STORAGE_KEY, theme);
+    }
+  }, [theme]);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+
+    const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
+
+    const handleChange = (event: MediaQueryListEvent) => {
+      if (hasExplicitPreference.current) return;
+      setThemeState(event.matches ? "dark" : "light");
+    };
+
+    mediaQuery.addEventListener("change", handleChange);
+    return () => mediaQuery.removeEventListener("change", handleChange);
+  }, []);
+
+  const setTheme = useCallback((value: Theme) => {
+    hasExplicitPreference.current = true;
+    setThemeState(value);
+  }, []);
+
+  const toggleTheme = useCallback(() => {
+    setTheme(theme === "dark" ? "light" : "dark");
+  }, [setTheme, theme]);
+
+  const value = useMemo<ThemeContextValue>(() => ({ theme, setTheme, toggleTheme }), [theme, setTheme, toggleTheme]);
+
+  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
+}
+
+export function useTheme() {
+  const context = useContext(ThemeContext);
+  if (!context) {
+    throw new Error("useTheme must be used within a ThemeProvider");
+  }
+  return context;
+}

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -4,11 +4,11 @@ import { cn } from "@/lib/util";
 
 const badgeVariants = {
   default:
-    "inline-flex items-center rounded-full bg-indigo-600 px-2.5 py-0.5 text-xs font-semibold text-white",
+    "inline-flex items-center rounded-full bg-primary px-2.5 py-0.5 text-xs font-semibold text-primary-foreground",
   secondary:
-    "inline-flex items-center rounded-full bg-slate-100 px-2.5 py-0.5 text-xs font-medium text-slate-700",
+    "inline-flex items-center rounded-full bg-muted px-2.5 py-0.5 text-xs font-medium text-muted-foreground",
   outline:
-    "inline-flex items-center rounded-full border border-slate-200 bg-white px-2.5 py-0.5 text-xs font-medium text-slate-700",
+    "inline-flex items-center rounded-full border border-border bg-card px-2.5 py-0.5 text-xs font-medium text-foreground",
 };
 
 type Variant = keyof typeof badgeVariants;

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -9,18 +9,18 @@ export interface ButtonProps
 }
 
 const buttonVariants =
-  "inline-flex h-9 items-center justify-center whitespace-nowrap rounded-md px-3 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-50 disabled:cursor-not-allowed disabled:opacity-60";
+  "inline-flex h-9 items-center justify-center whitespace-nowrap rounded-md px-3 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-60";
 
 export const buttonStyles = {
-  default: "bg-indigo-600 text-white hover:bg-indigo-700",
-  primary: "bg-indigo-600 text-white hover:bg-indigo-700",
+  default: "bg-primary text-primary-foreground hover:bg-primary/90",
+  primary: "bg-primary text-primary-foreground hover:bg-primary/90",
   secondary:
-    "border border-slate-300 bg-white text-slate-700 hover:bg-slate-50",
+    "border border-border bg-muted text-foreground hover:bg-muted/80",
   outline:
-    "border border-slate-300 bg-transparent text-slate-700 hover:bg-slate-50",
-  ghost: "text-slate-700 hover:bg-slate-100",
+    "border border-border bg-transparent text-foreground hover:bg-muted/80",
+  ghost: "text-foreground hover:bg-muted",
   destructive:
-    "bg-rose-600 text-white hover:bg-rose-700 focus-visible:ring-rose-500",
+    "bg-destructive text-destructive-foreground hover:bg-destructive/90 focus-visible:ring-destructive-border",
 };
 
 type VariantKey = keyof typeof buttonStyles;

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -7,7 +7,7 @@ export const Card = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDi
     <div
       ref={ref}
       className={cn(
-        "rounded-2xl border border-slate-200 bg-white p-6 shadow-sm",
+        "rounded-2xl border border-border bg-card p-6 shadow-sm",
         className,
       )}
       {...props}
@@ -39,7 +39,7 @@ export const CardDescription = React.forwardRef<
   HTMLParagraphElement,
   React.HTMLAttributes<HTMLParagraphElement>
 >(({ className, ...props }, ref) => (
-  <p ref={ref} className={cn("text-sm text-slate-600", className)} {...props} />
+  <p ref={ref} className={cn("text-sm text-muted-foreground", className)} {...props} />
 ));
 CardDescription.displayName = "CardDescription";
 

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -9,7 +9,7 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(({ className
     <input
       type={type}
       className={cn(
-        "flex h-9 w-full rounded-md border border-slate-300 bg-white px-3 text-sm shadow-sm transition-colors placeholder:text-slate-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-1 disabled:cursor-not-allowed disabled:bg-slate-100 disabled:opacity-60",
+        "flex h-9 w-full rounded-md border border-border bg-card px-3 text-sm shadow-sm transition-colors placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:bg-muted disabled:opacity-60",
         className,
       )}
       ref={ref}

--- a/src/components/ui/label.tsx
+++ b/src/components/ui/label.tsx
@@ -9,7 +9,7 @@ export const Label = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <LabelPrimitive.Root
     ref={ref}
-    className={cn("text-xs font-medium uppercase tracking-wide text-slate-700", className)}
+    className={cn("text-xs font-medium uppercase tracking-wide text-muted-foreground", className)}
     {...props}
   />
 ));

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -15,7 +15,7 @@ export const SelectTrigger = React.forwardRef<
   <SelectPrimitive.Trigger
     ref={ref}
     className={cn(
-      "flex h-9 w-full items-center justify-between rounded-md border border-slate-300 bg-white px-3 text-sm shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-1 disabled:cursor-not-allowed disabled:bg-slate-100 disabled:opacity-60",
+      "flex h-9 w-full items-center justify-between rounded-md border border-border bg-card px-3 text-sm shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:bg-muted disabled:opacity-60",
       className,
     )}
     {...props}
@@ -36,7 +36,7 @@ export const SelectContent = React.forwardRef<
     <SelectPrimitive.Content
       ref={ref}
       className={cn(
-        "z-50 min-w-[8rem] overflow-hidden rounded-md border border-slate-200 bg-white text-slate-900 shadow-lg",
+        "z-50 min-w-[8rem] overflow-hidden rounded-md border border-border bg-card text-card-foreground shadow-lg",
         className,
       )}
       position={position}
@@ -56,7 +56,7 @@ export const SelectLabel = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <SelectPrimitive.Label
     ref={ref}
-    className={cn("px-2 py-1.5 text-xs font-semibold uppercase text-slate-500", className)}
+    className={cn("px-2 py-1.5 text-xs font-semibold uppercase text-muted-foreground", className)}
     {...props}
   />
 ));
@@ -69,7 +69,7 @@ export const SelectItem = React.forwardRef<
   <SelectPrimitive.Item
     ref={ref}
       className={cn(
-        "relative flex w-full cursor-pointer select-none items-center rounded-md px-2 py-1.5 text-sm outline-none focus:bg-slate-100 focus:text-slate-900",
+        "relative flex w-full cursor-pointer select-none items-center rounded-md px-2 py-1.5 text-sm outline-none focus:bg-muted focus:text-foreground",
         className,
       )}
     {...props}

--- a/src/components/ui/separator.tsx
+++ b/src/components/ui/separator.tsx
@@ -12,7 +12,7 @@ export const Separator = React.forwardRef<
     decorative={decorative}
     orientation={orientation}
     className={cn(
-      "shrink-0 bg-slate-200",
+      "shrink-0 bg-border",
       orientation === "horizontal" ? "h-px w-full" : "h-full w-px",
       className,
     )}

--- a/src/components/ui/switch.tsx
+++ b/src/components/ui/switch.tsx
@@ -10,13 +10,13 @@ export const Switch = React.forwardRef<
   <SwitchPrimitives.Root
     ref={ref}
     className={cn(
-      "peer inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border border-transparent bg-slate-300 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-50 disabled:cursor-not-allowed disabled:opacity-60 data-[state=checked]:bg-indigo-600",
+      "peer inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border border-transparent bg-muted transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-60 data-[state=checked]:bg-primary",
       className,
     )}
     {...props}
   >
     <SwitchPrimitives.Thumb
-      className="pointer-events-none block h-4 w-4 translate-x-0.5 rounded-full bg-white shadow transition-transform data-[state=checked]:translate-x-[18px]"
+      className="pointer-events-none block h-4 w-4 translate-x-0.5 rounded-full bg-card shadow transition-transform data-[state=checked]:translate-x-[18px]"
     />
   </SwitchPrimitives.Root>
 ));

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -12,7 +12,7 @@ export const TabsList = React.forwardRef<
   <TabsPrimitive.List
     ref={ref}
     className={cn(
-      "inline-flex h-10 items-center justify-center rounded-full border border-slate-200 bg-white p-1 text-slate-600 shadow-sm",
+      "inline-flex h-10 items-center justify-center rounded-full border border-border bg-muted p-1 text-muted-foreground shadow-sm",
       className,
     )}
     {...props}
@@ -27,7 +27,7 @@ export const TabsTrigger = React.forwardRef<
   <TabsPrimitive.Trigger
     ref={ref}
     className={cn(
-      "inline-flex min-w-[110px] items-center justify-center whitespace-nowrap rounded-full px-4 py-1.5 text-sm font-medium transition-all data-[state=active]:bg-slate-100 data-[state=active]:text-slate-900 data-[state=active]:shadow-sm",
+      "inline-flex min-w-[110px] items-center justify-center whitespace-nowrap rounded-full px-4 py-1.5 text-sm font-medium transition-all data-[state=active]:bg-card data-[state=active]:text-foreground data-[state=active]:shadow-sm",
       className,
     )}
     {...props}

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -16,7 +16,7 @@ export const TooltipContent = React.forwardRef<
       ref={ref}
       sideOffset={sideOffset}
       className={cn(
-        "z-50 max-w-xs rounded-md bg-slate-900 px-3 py-2 text-xs text-white shadow-lg",
+        "z-50 max-w-xs rounded-md border border-border bg-card px-3 py-2 text-xs text-card-foreground shadow-lg",
         className,
       )}
       {...props}

--- a/src/index.css
+++ b/src/index.css
@@ -2,16 +2,104 @@
 @tailwind components;
 @tailwind utilities;
 
-:root {
-  --background: 255 255 255;
-  --foreground: 15 23 42;
-  --muted: 248 250 252;
-  --muted-foreground: 100 116 139;
-  --card: 255 255 255;
-  --card-foreground: 15 23 42;
-  --border: 226 232 240;
-  --input: 203 213 225;
-  --ring: 99 102 241;
+@layer base {
+  :root {
+    color-scheme: light;
+    --background: 248 250 252;
+    --foreground: 15 23 42;
+    --muted: 241 245 249;
+    --muted-foreground: 71 85 105;
+    --card: 255 255 255;
+    --card-foreground: 15 23 42;
+    --border: 226 232 240;
+    --input: 203 213 225;
+    --ring: 79 70 229;
+    --primary: 79 70 229;
+    --primary-foreground: 255 255 255;
+    --accent: 238 242 255;
+    --accent-foreground: 67 56 202;
+    --accent-border: 199 210 254;
+    --success: 236 253 245;
+    --success-foreground: 4 120 87;
+    --success-border: 134 239 172;
+    --destructive: 255 241 242;
+    --destructive-foreground: 190 24 93;
+    --destructive-border: 254 202 210;
+    --tier-2-start: 110 231 183;
+    --tier-2-end: 16 185 129;
+    --tier-3-start: 125 211 252;
+    --tier-3-end: 14 165 233;
+    --tier-4-start: 196 181 253;
+    --tier-4-end: 139 92 246;
+    --tier-5-start: 253 230 138;
+    --tier-5-end: 217 119 6;
+  }
+
+  @media (prefers-color-scheme: dark) {
+    :root {
+      color-scheme: dark;
+      --background: 15 23 42;
+      --foreground: 226 232 240;
+      --muted: 30 41 59;
+      --muted-foreground: 148 163 184;
+      --card: 17 24 39;
+      --card-foreground: 226 232 240;
+      --border: 51 65 85;
+      --input: 71 85 105;
+      --ring: 129 140 248;
+      --primary: 129 140 248;
+      --primary-foreground: 15 23 42;
+      --accent: 76 106 179;
+      --accent-foreground: 229 236 255;
+      --accent-border: 129 161 218;
+      --success: 19 78 74;
+      --success-foreground: 167 243 208;
+      --success-border: 45 212 191;
+      --destructive: 136 19 55;
+      --destructive-foreground: 255 228 236;
+      --destructive-border: 244 114 182;
+      --tier-2-start: 45 212 191;
+      --tier-2-end: 13 148 136;
+      --tier-3-start: 56 189 248;
+      --tier-3-end: 3 105 161;
+      --tier-4-start: 167 139 250;
+      --tier-4-end: 124 58 237;
+      --tier-5-start: 253 224 71;
+      --tier-5-end: 194 65 12;
+    }
+  }
+
+  .dark {
+    color-scheme: dark;
+    --background: 15 23 42;
+    --foreground: 226 232 240;
+    --muted: 30 41 59;
+    --muted-foreground: 148 163 184;
+    --card: 17 24 39;
+    --card-foreground: 226 232 240;
+    --border: 51 65 85;
+    --input: 71 85 105;
+    --ring: 129 140 248;
+    --primary: 129 140 248;
+    --primary-foreground: 15 23 42;
+    --accent: 76 106 179;
+    --accent-foreground: 229 236 255;
+    --accent-border: 129 161 218;
+    --success: 19 78 74;
+    --success-foreground: 167 243 208;
+    --success-border: 45 212 191;
+    --destructive: 136 19 55;
+    --destructive-foreground: 255 228 236;
+    --destructive-border: 244 114 182;
+    --tier-2-start: 45 212 191;
+    --tier-2-end: 13 148 136;
+    --tier-3-start: 56 189 248;
+    --tier-3-end: 3 105 161;
+    --tier-4-start: 167 139 250;
+    --tier-4-end: 124 58 237;
+    --tier-5-start: 253 224 71;
+    --tier-5-end: 194 65 12;
+  }
 }
 
 html,
@@ -24,10 +112,11 @@ body,
   body {
     margin: 0;
     font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-    background-color: #f8fafc;
-    color: #0f172a;
+    background-color: rgb(var(--background));
+    color: rgb(var(--foreground));
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
+    transition: background-color 150ms ease, color 150ms ease;
   }
 }
 

--- a/src/lib/rules.ts
+++ b/src/lib/rules.ts
@@ -48,7 +48,7 @@ export const TIER_RULES: Record<TierKey, TierRule> = {
   T2: {
     label: "Tier 2 · Fine Essence",
     subtitle: "Refine Raw → Fine",
-    gradient: "from-emerald-500/20 via-emerald-500/10 to-emerald-500/5",
+    gradient: "from-tier-2-start/20 via-tier-2-start/10 to-tier-2-end/5",
     success: { fine: 1 },
     risks: {
       low: {
@@ -73,7 +73,7 @@ export const TIER_RULES: Record<TierKey, TierRule> = {
   T3: {
     label: "Tier 3 · Fused Essence",
     subtitle: "Infuse Fine + RawAE → Fused",
-    gradient: "from-sky-500/20 via-sky-500/10 to-sky-500/5",
+    gradient: "from-tier-3-start/20 via-tier-3-start/10 to-tier-3-end/5",
     success: { fused: 1 },
     risks: {
       standard: {
@@ -87,7 +87,7 @@ export const TIER_RULES: Record<TierKey, TierRule> = {
   T4: {
     label: "Tier 4 · Superior Essence",
     subtitle: "Refine Fused (+RawAE) → Superior",
-    gradient: "from-violet-500/20 via-violet-500/10 to-violet-500/5",
+    gradient: "from-tier-4-start/20 via-tier-4-start/10 to-tier-4-end/5",
     success: { superior: 1 },
     allowExtraRawAE: true,
     risks: {
@@ -114,7 +114,7 @@ export const TIER_RULES: Record<TierKey, TierRule> = {
   T5: {
     label: "Tier 5 · Supreme Essence",
     subtitle: "Refine Superior → Supreme",
-    gradient: "from-amber-500/30 via-amber-500/15 to-amber-500/5",
+    gradient: "from-tier-5-start/30 via-tier-5-start/15 to-tier-5-end/5",
     success: { supreme: 1 },
     risks: {
       standard: {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,9 +2,12 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.tsx'
+import { ThemeProvider } from '@/components/theme/ThemeProvider'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    <ThemeProvider>
+      <App />
+    </ThemeProvider>
   </StrictMode>,
 )

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,10 +1,55 @@
 import type { Config } from "tailwindcss";
 
+const withOpacity = (variable: string) => `rgb(var(${variable}) / <alpha-value>)`;
+
 const config: Config = {
   darkMode: ["class"],
   content: ["./index.html", "./src/**/*.{ts,tsx}"],
   theme: {
-    extend: {},
+    extend: {
+      colors: {
+        border: withOpacity("--border"),
+        input: withOpacity("--input"),
+        ring: withOpacity("--ring"),
+        background: withOpacity("--background"),
+        foreground: withOpacity("--foreground"),
+        card: {
+          DEFAULT: withOpacity("--card"),
+          foreground: withOpacity("--card-foreground"),
+        },
+        muted: {
+          DEFAULT: withOpacity("--muted"),
+          foreground: withOpacity("--muted-foreground"),
+        },
+        primary: {
+          DEFAULT: withOpacity("--primary"),
+          foreground: withOpacity("--primary-foreground"),
+        },
+        accent: {
+          DEFAULT: withOpacity("--accent"),
+          foreground: withOpacity("--accent-foreground"),
+        },
+        success: {
+          DEFAULT: withOpacity("--success"),
+          foreground: withOpacity("--success-foreground"),
+        },
+        destructive: {
+          DEFAULT: withOpacity("--destructive"),
+          foreground: withOpacity("--destructive-foreground"),
+        },
+        "accent-border": withOpacity("--accent-border"),
+        "success-border": withOpacity("--success-border"),
+        "destructive-border": withOpacity("--destructive-border"),
+        "tier-2-start": withOpacity("--tier-2-start"),
+        "tier-2-end": withOpacity("--tier-2-end"),
+        "tier-3-start": withOpacity("--tier-3-start"),
+        "tier-3-end": withOpacity("--tier-3-end"),
+        "tier-4-start": withOpacity("--tier-4-start"),
+        "tier-4-end": withOpacity("--tier-4-end"),
+        "tier-5-start": withOpacity("--tier-5-start"),
+        "tier-5-end": withOpacity("--tier-5-end"),
+      },
+    },
   },
   plugins: [],
 };


### PR DESCRIPTION
## Summary
- define light and dark CSS variables, expose them through Tailwind tokens, and update components to rely on semantic colors
- add a ThemeProvider with a dark-mode toggle in the settings panel and wrap the app to honour system preferences
- document the theming controls and cover theme switching with new Vitest checks

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68e10f3774f48333ae4f493d63ba16bc