### PR TITLE
Reset store state when persisted data is cleared

### DIFF
--- a/src/app/store.ts
+++ b/src/app/store.ts
@@ -1,3 +1,4 @@
+import { useEffect, useLayoutEffect } from "react";
 import { create } from "zustand";
 import { createJSONStorage, persist } from "zustand/middleware";
 import type { StateStorage } from "zustand/middleware";
@@ -118,6 +119,8 @@ const memoryStorage = (() => {
 const storageCreator = () =>
   typeof window !== "undefined" ? window.localStorage : memoryStorage;
 
+const useClientLayoutEffect = typeof window !== "undefined" ? useLayoutEffect : useEffect;
+
 export const useNaturalEssenceStore = create<NaturalEssenceCraftingStore>()(
   persist(
     (set, get) => ({
@@ -218,3 +221,20 @@ export const useNaturalEssenceStore = create<NaturalEssenceCraftingStore>()(
 );
 
 export const getDefaultState = createDefaultState;
+
+export function useResetStoreOnMissingPersistedState(): void {
+  useClientLayoutEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    try {
+      const persistedState = window.localStorage.getItem(STORAGE_KEY);
+      if (persistedState === null) {
+        useNaturalEssenceStore.getState().resetState();
+      }
+    } catch {
+      useNaturalEssenceStore.getState().resetState();
+    }
+  }, []);
+}

--- a/src/components/NaturalEssenceCraftingApp.tsx
+++ b/src/components/NaturalEssenceCraftingApp.tsx
@@ -48,6 +48,7 @@ import {
   type ActionLogEntry,
   type RollRecord,
   useNaturalEssenceStore,
+  useResetStoreOnMissingPersistedState,
 } from "@/app/store";
 import { clampInt, cn, d20, formatMinutes, parseCSVInts } from "@/lib/util";
 
@@ -171,6 +172,7 @@ export function NaturalEssenceCraftingApp({
   compactMode,
   onToggleCompactMode,
 }: NaturalEssenceCraftingAppProps) {
+  useResetStoreOnMissingPersistedState();
   const inventory = useNaturalEssenceStore((store) => store.inventory);
   const settings = useNaturalEssenceStore((store) => store.settings);
   const log = useNaturalEssenceStore((store) => store.log);


### PR DESCRIPTION
## Summary
- add a React hook that resets the zustand store when persisted data has been cleared
- invoke the hook from the main app component so each mount starts from default state when storage is empty

## Testing
- npm test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68e1144f69748333a931461a91e3fe61